### PR TITLE
feat(port): add portable C serial port layer for esp-serial-flasher

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.16)
+
+if(WIN32)
+    set(SERIAL_PLATFORM_SRC platform/win/serial.c)
+    set(SERIAL_PLATFORM_LIBS advapi32)
+else()
+    set(SERIAL_PLATFORM_SRC platform/posix/serial.c)
+    set(SERIAL_PLATFORM_LIBS "")
+endif()
+
+add_library(esf_port STATIC
+    esf_port.c
+    ${SERIAL_PLATFORM_SRC}
+)
+
+target_include_directories(esf_port
+    PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR}
+    PRIVATE ${ESP_SERIAL_FLASHER_INCLUDE_DIR}
+)
+
+target_link_libraries(esf_port
+    PRIVATE ${SERIAL_PLATFORM_LIBS}
+)

--- a/port/esf_port.c
+++ b/port/esf_port.c
@@ -1,0 +1,323 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "esf_port.h"
+#include "serial.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+/* ------------------------------------------------------------------ */
+/*  Platform-specific monotonic clock and sleep                        */
+
+#ifdef _WIN32
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>
+static uint64_t mono_ms(void)   { return (uint64_t)GetTickCount64(); }
+static void     delay_ms(uint32_t ms) { Sleep(ms); }
+#else
+#  include <time.h>
+#  include <unistd.h>
+static uint64_t mono_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000u + (uint64_t)ts.tv_nsec / 1000000u;
+}
+static void delay_ms(uint32_t ms) { usleep((useconds_t)ms * 1000u); }
+#endif
+
+/* ------------------------------------------------------------------ */
+/*  Timing constants (overridable via -D at build time)                */
+
+#ifndef SERIAL_FLASHER_RESET_HOLD_TIME_MS
+#define SERIAL_FLASHER_RESET_HOLD_TIME_MS 100
+#endif
+#ifndef SERIAL_FLASHER_BOOT_HOLD_TIME_MS
+#define SERIAL_FLASHER_BOOT_HOLD_TIME_MS  50
+#endif
+#define PORT_REOPEN_TIMEOUT_MS 3000
+
+/* ------------------------------------------------------------------ */
+/*  USB JTAG Serial port re-enumeration                                */
+
+/*
+ * After a USB JTAG Serial reset the device re-enumerates and its port
+ * node disappears briefly.  Close the current fd, then poll serial_open()
+ * until the port reappears or the timeout expires.
+ */
+static esp_loader_error_t esf_wait_port_reopen(esf_port_t *p,
+                                                uint32_t timeout_ms)
+{
+    serial_close(p->_serial);
+    p->_serial = NULL;
+
+    uint64_t deadline = mono_ms() + timeout_ms;
+
+    while (mono_ms() < deadline) {
+        delay_ms(100);
+        if (serial_open(&p->_serial, p->device) == 0 &&
+            serial_set_baud(p->_serial, p->baudrate) == 0)
+            return ESP_LOADER_SUCCESS;
+        if (p->_serial) {
+            serial_close(p->_serial);
+            p->_serial = NULL;
+        }
+    }
+
+    fprintf(stderr, "esf_port: timed out waiting for %s to reappear\n",
+            p->device);
+    return ESP_LOADER_ERROR_TIMEOUT;
+}
+
+/* ------------------------------------------------------------------ */
+/*  init / deinit                                                       */
+
+static esp_loader_error_t port_init(esp_loader_port_t *port)
+{
+    esf_port_t *p = container_of(port, esf_port_t, port);
+
+    p->_time_end    = 0;
+    p->_is_usb_jtag = 0;
+
+    if (serial_open(&p->_serial, p->device) != 0) {
+        fprintf(stderr, "esf_port: cannot open %s\n", p->device);
+        return ESP_LOADER_ERROR_FAIL;
+    }
+
+    if (serial_set_baud(p->_serial, p->baudrate) != 0) {
+        fprintf(stderr, "esf_port: cannot set baud %u on %s\n",
+                p->baudrate, p->device);
+        serial_close(p->_serial);
+        p->_serial = NULL;
+        return ESP_LOADER_ERROR_FAIL;
+    }
+
+    unsigned int vid = 0, pid = 0;
+    p->_is_usb_jtag = (serial_get_usb_id(p->device, &vid, &pid) == 0 &&
+                       vid == 0x303A && pid == 0x1001);
+    return ESP_LOADER_SUCCESS;
+}
+
+static void port_deinit(esp_loader_port_t *port)
+{
+    esf_port_t *p = container_of(port, esf_port_t, port);
+    serial_close(p->_serial);
+    p->_serial = NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/*  I/O                                                                 */
+
+static esp_loader_error_t port_write(esp_loader_port_t *port,
+                                     const uint8_t *data,
+                                     uint16_t size, uint32_t timeout)
+{
+    esf_port_t *p = container_of(port, esf_port_t, port);
+    (void)timeout; /* deadline is owned by start_timer / remaining_time */
+    return (serial_write(p->_serial, data, size) < 0)
+               ? ESP_LOADER_ERROR_FAIL
+               : ESP_LOADER_SUCCESS;
+}
+
+static esp_loader_error_t port_read(esp_loader_port_t *port,
+                                    uint8_t *data,
+                                    uint16_t size, uint32_t timeout)
+{
+    esf_port_t *p = container_of(port, esf_port_t, port);
+    (void)timeout;
+
+    for (uint16_t i = 0; i < size; i++) {
+        int64_t remaining = p->_time_end - (int64_t)mono_ms();
+        unsigned ms = (remaining > 0) ? (unsigned)remaining : 0u;
+        ssize_t n = serial_read(p->_serial, &data[i], 1, ms);
+        if (n == 0)
+            return ESP_LOADER_ERROR_TIMEOUT;
+        if (n < 0)
+            return ESP_LOADER_ERROR_FAIL;
+    }
+    return ESP_LOADER_SUCCESS;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Timer                                                               */
+
+static void port_start_timer(esp_loader_port_t *port, uint32_t ms)
+{
+    esf_port_t *p = container_of(port, esf_port_t, port);
+    p->_time_end = (int64_t)mono_ms() + (int64_t)ms;
+}
+
+static uint32_t port_remaining_time(esp_loader_port_t *port)
+{
+    esf_port_t *p = container_of(port, esf_port_t, port);
+    int64_t remaining = p->_time_end - (int64_t)mono_ms();
+    return (remaining > 0) ? (uint32_t)remaining : 0u;
+}
+
+static void port_delay_ms(esp_loader_port_t *port, uint32_t ms)
+{
+    (void)port;
+    delay_ms(ms);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Baud rate                                                           */
+
+static esp_loader_error_t port_change_rate(esp_loader_port_t *port,
+                                           uint32_t rate)
+{
+    esf_port_t *p = container_of(port, esf_port_t, port);
+    return (serial_set_baud(p->_serial, (unsigned)rate) == 0)
+               ? ESP_LOADER_SUCCESS
+               : ESP_LOADER_ERROR_FAIL;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Reset sequences                                                     */
+
+static void port_reset_target(esp_loader_port_t *port)
+{
+    esf_port_t *p = container_of(port, esf_port_t, port);
+
+    /* Hard reset: pulse RESET with BOOT deasserted so the chip runs the
+     * application, not the bootloader.  Both lines are driven together so
+     * the bridge sees a clean edge.  USB JTAG Serial devices re-enumerate
+     * after reset; wait for the port to reappear. */
+    serial_set_dtr_rts(p->_serial, 0, 1); /* BOOT=high  RESET=low  */
+    delay_ms(SERIAL_FLASHER_RESET_HOLD_TIME_MS);
+    serial_set_dtr_rts(p->_serial, 0, 0); /* BOOT=high  RESET=high */
+
+    if (p->_is_usb_jtag)
+        esf_wait_port_reopen(p, PORT_REOPEN_TIMEOUT_MS);
+}
+
+static void port_enter_bootloader(esp_loader_port_t *port)
+{
+    esf_port_t *p = container_of(port, esf_port_t, port);
+
+    if (p->_is_usb_jtag) {
+        /* USBJTAGSerialReset — required for chips that expose their own
+         * USB JTAG/Serial peripheral (ESP32-C3, S3, C6, H2, P4).
+         *
+         * All steps use serial_set_dtr_rts() so both lines change in one
+         * driver call, giving a clean edge even through the USB frame.
+         *
+         * Convention (standard inverting circuit):
+         *   DTR=1 → BOOT pin LOW   (enter bootloader)
+         *   RTS=1 → RESET pin LOW  (chip held in reset)
+         *
+         *  idle      → (0,0)
+         *  BOOT low  → (1,0)  assert BOOT before reset
+         *  RESET low → (1,1)  chip in reset, BOOT already latched
+         *  rel BOOT  → (0,1)  through (0,1) avoids (1,1)→(0,0) glitch
+         *  rel RESET → (0,0)  chip exits reset → ROM sees BOOT=low → bootloader
+         */
+        serial_set_dtr_rts(p->_serial, 0, 0);
+        delay_ms(SERIAL_FLASHER_RESET_HOLD_TIME_MS);
+        serial_set_dtr_rts(p->_serial, 1, 0);
+        delay_ms(SERIAL_FLASHER_RESET_HOLD_TIME_MS);
+        serial_set_dtr_rts(p->_serial, 1, 1);
+        serial_set_dtr_rts(p->_serial, 0, 1);
+        delay_ms(SERIAL_FLASHER_RESET_HOLD_TIME_MS);
+        serial_set_dtr_rts(p->_serial, 0, 0);
+        esf_wait_port_reopen(p, PORT_REOPEN_TIMEOUT_MS);
+    } else {
+        /* Standard auto-reset circuit (CP2102, CH340, FT232, …).
+         *
+         * serial_set_dtr_rts() is atomic on POSIX (single TIOCMSET ioctl)
+         * and driver-batched on Windows, so this one sequence covers both
+         * ClassicReset and UnixTightReset from esptool — no separate paths
+         * are needed.
+         *
+         * The through-(1,1) step prevents a (0,0)→(0,1) intermediate state
+         * that would briefly deassert BOOT before RESET goes low, causing
+         * the ROM to latch the wrong boot mode.
+         *
+         *  idle         → (0,0)
+         *  via (1,1)    → (1,1)  transition through known state
+         *  RESET low    → (0,1)  BOOT=high, RESET=low — chip held in reset
+         *  BOOT low     → (1,0)  RESET released with BOOT asserted → bootloader
+         *  release      → (0,0)  BOOT released, chip runs in bootloader
+         */
+        serial_set_dtr_rts(p->_serial, 0, 0);
+        serial_set_dtr_rts(p->_serial, 1, 1);
+        serial_set_dtr_rts(p->_serial, 0, 1);
+        delay_ms(SERIAL_FLASHER_RESET_HOLD_TIME_MS);
+        serial_set_dtr_rts(p->_serial, 1, 0);
+        delay_ms(SERIAL_FLASHER_BOOT_HOLD_TIME_MS);
+        serial_set_dtr_rts(p->_serial, 0, 0);
+        serial_flush_input(p->_serial);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Port probing                                                        */
+
+char *esf_find_esp_port(void)
+{
+    char **ports;
+    int n = serial_list_ports(&ports);
+    if (n <= 0)
+        return NULL;
+
+    char *found = NULL;
+    for (int i = 0; ports[i] && !found; i++) {
+        fprintf(stderr, "  Trying %s...", ports[i]);
+        fflush(stderr);
+
+        esf_port_t sport = {
+            .port.ops = &esf_port_ops,
+            .device   = ports[i],
+            .baudrate = 115200,
+        };
+
+        esp_loader_t probe;
+        if (esp_loader_init_uart(&probe, &sport.port) != ESP_LOADER_SUCCESS) {
+            fprintf(stderr, " open failed\n");
+            continue;
+        }
+
+        esp_loader_connect_args_t ca = ESP_LOADER_CONNECT_DEFAULT();
+        if (esp_loader_connect(&probe, &ca) == ESP_LOADER_SUCCESS) {
+            fprintf(stderr, " found ESP chip\n");
+            esp_loader_reset_target(&probe);
+            size_t len = strlen(ports[i]);
+            found = malloc(len + 1);
+            if (found)
+                memcpy(found, ports[i], len + 1);
+        } else {
+            fprintf(stderr, " no response\n");
+        }
+        esp_loader_deinit(&probe);
+    }
+
+    serial_free_port_list(ports);
+    return found;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Vtable                                                              */
+
+const esp_loader_port_ops_t esf_port_ops = {
+    .init                     = port_init,
+    .deinit                   = port_deinit,
+    .enter_bootloader         = port_enter_bootloader,
+    .reset_target             = port_reset_target,
+    .start_timer              = port_start_timer,
+    .remaining_time           = port_remaining_time,
+    .delay_ms                 = port_delay_ms,
+    .debug_print              = NULL,
+    .change_transmission_rate = port_change_rate,
+    .write                    = port_write,
+    .read                     = port_read,
+    .spi_set_cs               = NULL,
+    .sdio_write               = NULL,
+    .sdio_read                = NULL,
+    .sdio_card_init           = NULL,
+};

--- a/port/esf_port.h
+++ b/port/esf_port.h
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file esf_port.h
+ * @brief esp-serial-flasher port backed by the esp-ice serial API.
+ *
+ * Usage:
+ * @code
+ *   esf_port_t p = {
+ *       .port.ops = &esf_port_ops,
+ *       .device   = "/dev/ttyUSB0",
+ *       .baudrate = 115200,
+ *   };
+ *   esp_loader_t loader;
+ *   esp_loader_init_uart(&loader, &p.port);
+ * @endcode
+ */
+
+#ifndef ESF_PORT_H
+#define ESF_PORT_H
+
+#include "esp_loader.h"
+#include "esp_loader_io.h"
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque serial handle — definition is platform-specific. */
+struct serial;
+
+/**
+ * Concrete port instance. Embed as the first step before calling
+ * esp_loader_init_uart(); container_of recovers it inside every callback.
+ */
+typedef struct {
+    esp_loader_port_t  port;      /**< Must be first — pass &port to init */
+
+    /* Public: fill before calling esp_loader_init_uart() */
+    const char *device;           /**< e.g. "/dev/ttyUSB0" or "COM3"      */
+    unsigned    baudrate;         /**< Initial baud rate, e.g. 115200      */
+
+    /* Private runtime state — do not access directly */
+    struct serial *_serial;       /**< Opened by init, closed by deinit    */
+    int64_t        _time_end;     /**< Deadline set by start_timer         */
+    int            _is_usb_jtag;  /**< 1 when VID=0x303A PID=0x1001       */
+} esf_port_t;
+
+/** Operations vtable — assign to port.ops before calling init. */
+extern const esp_loader_port_ops_t esf_port_ops;
+
+/**
+ * Probe all available serial ports and return the path of the first one
+ * that responds as an ESP chip.  The device is reset to run mode before
+ * returning.  Returns a heap-allocated string the caller must free(), or
+ * NULL if no ESP chip was found.
+ */
+char *esf_find_esp_port(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESF_PORT_H */

--- a/port/platform/posix/serial.c
+++ b/port/platform/posix/serial.c
@@ -1,0 +1,309 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "serial.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <glob.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/select.h>
+#include <termios.h>
+#include <unistd.h>
+
+#ifdef __APPLE__
+#  include <IOKit/serial/ioss.h>  /* IOSSIOSPEED for non-standard rates */
+#endif
+
+struct serial {
+    int      fd;
+    unsigned baudrate;
+    char    *device;
+};
+
+/* Map numeric baud rate to termios speed constant, or B0 if unknown. */
+static speed_t baud_to_speed(unsigned baud)
+{
+    static const struct { unsigned baud; speed_t speed; } table[] = {
+        {    9600,    B9600   },
+        {   19200,   B19200  },
+        {   38400,   B38400  },
+        {   57600,   B57600  },
+        {  115200,  B115200  },
+        {  230400,  B230400  },
+#ifdef B460800
+        {  460800,  B460800  },
+#endif
+#ifdef B921600
+        {  921600,  B921600  },
+#endif
+#ifdef B1500000
+        { 1500000, B1500000  },
+#endif
+#ifdef B2000000
+        { 2000000, B2000000  },
+#endif
+    };
+    for (size_t i = 0; i < sizeof(table) / sizeof(table[0]); i++)
+        if (table[i].baud == baud)
+            return table[i].speed;
+    return B0;
+}
+
+int serial_open(struct serial **out, const char *path)
+{
+    struct serial *s = calloc(1, sizeof(*s));
+    if (!s)
+        return -ENOMEM;
+
+    s->device = strdup(path);
+    if (!s->device) {
+        free(s);
+        return -ENOMEM;
+    }
+
+    /* O_NONBLOCK prevents open() from blocking if carrier is not present. */
+    s->fd = open(path, O_RDWR | O_NOCTTY | O_NONBLOCK);
+    if (s->fd < 0) {
+        int err = -errno;
+        free(s->device);
+        free(s);
+        return err;
+    }
+
+    /* Switch back to blocking I/O after open succeeds. */
+    int flags = fcntl(s->fd, F_GETFL);
+    fcntl(s->fd, F_SETFL, flags & ~O_NONBLOCK);
+
+    struct termios tty;
+    if (tcgetattr(s->fd, &tty) != 0) {
+        int err = -errno;
+        close(s->fd);
+        free(s->device);
+        free(s);
+        return err;
+    }
+
+    cfmakeraw(&tty);
+    tty.c_cflag |= (CLOCAL | CREAD);
+    tty.c_cflag &= ~CRTSCTS;
+    tty.c_cc[VMIN]  = 0;
+    tty.c_cc[VTIME] = 0;
+
+    cfsetispeed(&tty, B115200);
+    cfsetospeed(&tty, B115200);
+    s->baudrate = 115200;
+
+    if (tcsetattr(s->fd, TCSANOW, &tty) != 0) {
+        int err = -errno;
+        close(s->fd);
+        free(s->device);
+        free(s);
+        return err;
+    }
+
+    *out = s;
+    return 0;
+}
+
+void serial_close(struct serial *s)
+{
+    if (!s)
+        return;
+    if (s->fd >= 0)
+        close(s->fd);
+    free(s->device);
+    free(s);
+}
+
+int serial_set_baud(struct serial *s, unsigned baud)
+{
+    struct termios tty;
+    if (tcgetattr(s->fd, &tty) != 0)
+        return -errno;
+
+    speed_t sp = baud_to_speed(baud);
+    if (sp != B0) {
+        cfsetispeed(&tty, sp);
+        cfsetospeed(&tty, sp);
+        if (tcsetattr(s->fd, TCSANOW, &tty) != 0)
+            return -errno;
+    } else {
+#ifdef __APPLE__
+        speed_t speed = (speed_t)baud;
+        if (ioctl(s->fd, IOSSIOSPEED, &speed) != 0)
+            return -errno;
+#else
+        return -EINVAL;
+#endif
+    }
+
+    s->baudrate = baud;
+    return 0;
+}
+
+ssize_t serial_read(struct serial *s, void *buf, size_t n, unsigned timeout_ms)
+{
+    fd_set fds;
+    FD_ZERO(&fds);
+    FD_SET(s->fd, &fds);
+
+    struct timeval tv = {
+        .tv_sec  = timeout_ms / 1000,
+        .tv_usec = (timeout_ms % 1000) * 1000,
+    };
+
+    int r = select(s->fd + 1, &fds, NULL, NULL, &tv);
+    if (r < 0)
+        return -1;
+    if (r == 0)
+        return 0;  /* timeout */
+
+    return read(s->fd, buf, n);
+}
+
+ssize_t serial_write(struct serial *s, const void *buf, size_t n)
+{
+    const uint8_t *p = (const uint8_t *)buf;
+    size_t written = 0;
+    while (written < n) {
+        ssize_t r = write(s->fd, p + written, n - written);
+        if (r < 0) {
+            if (errno == EINTR)
+                continue;
+            return -1;
+        }
+        written += (size_t)r;
+    }
+    return (ssize_t)written;
+}
+
+static void set_modem_bit(struct serial *s, int bit, int on)
+{
+    /* Ignore errors: ENOTTY/EINVAL means the port doesn't support modem lines. */
+    ioctl(s->fd, on ? TIOCMBIS : TIOCMBIC, &bit);
+}
+
+void serial_set_dtr(struct serial *s, int on)
+{
+    set_modem_bit(s, TIOCM_DTR, on);
+}
+
+void serial_set_rts(struct serial *s, int on)
+{
+    set_modem_bit(s, TIOCM_RTS, on);
+}
+
+void serial_set_dtr_rts(struct serial *s, int dtr, int rts)
+{
+    int bits;
+    if (ioctl(s->fd, TIOCMGET, &bits) < 0)
+        return;
+
+    if (dtr) bits |= TIOCM_DTR; else bits &= ~TIOCM_DTR;
+    if (rts) bits |= TIOCM_RTS; else bits &= ~TIOCM_RTS;
+
+    ioctl(s->fd, TIOCMSET, &bits);
+}
+
+void serial_flush_input(struct serial *s)
+{
+    tcflush(s->fd, TCIFLUSH);
+}
+
+int serial_list_ports(char ***ports_out)
+{
+    static const char *const patterns[] = {
+        "/dev/ttyUSB*",
+        "/dev/ttyACM*",
+#ifdef __APPLE__
+        "/dev/tty.usbserial*",
+        "/dev/tty.usbmodem*",
+        "/dev/tty.SLAB_USBtoUART*",
+        "/dev/tty.wchusbserial*",
+#endif
+        NULL,
+    };
+
+    glob_t gl = { 0 };
+    int gl_flags = GLOB_ERR;
+
+    for (int i = 0; patterns[i]; i++) {
+        glob(patterns[i],
+             (i == 0) ? gl_flags : (gl_flags | GLOB_APPEND),
+             NULL, &gl);
+    }
+
+    size_t total = gl.gl_pathc;
+    char **list = calloc(total + 1, sizeof(char *));
+    if (!list) {
+        globfree(&gl);
+        return -ENOMEM;
+    }
+
+    for (size_t i = 0; i < total; i++) {
+        list[i] = strdup(gl.gl_pathv[i]);
+        if (!list[i]) {
+            for (size_t j = 0; j < i; j++)
+                free(list[j]);
+            free(list);
+            globfree(&gl);
+            return -ENOMEM;
+        }
+    }
+    list[total] = NULL;
+    globfree(&gl);
+
+    *ports_out = list;
+    return (int)total;
+}
+
+void serial_free_port_list(char **ports)
+{
+    if (!ports)
+        return;
+    for (char **p = ports; *p; p++)
+        free(*p);
+    free(ports);
+}
+
+int serial_get_usb_id(const char *device, unsigned int *vid, unsigned int *pid)
+{
+#ifdef __linux__
+    const char *base = strrchr(device, '/');
+    base = base ? base + 1 : device;
+
+    char path[256];
+    snprintf(path, sizeof(path),
+             "/sys/class/tty/%s/device/../idVendor", base);
+    FILE *f = fopen(path, "r");
+    if (!f)
+        return -ENOENT;
+    if (fscanf(f, "%x", vid) != 1) {
+        fclose(f);
+        return -EIO;
+    }
+    fclose(f);
+
+    snprintf(path, sizeof(path),
+             "/sys/class/tty/%s/device/../idProduct", base);
+    f = fopen(path, "r");
+    if (!f)
+        return -ENOENT;
+    if (fscanf(f, "%x", pid) != 1) {
+        fclose(f);
+        return -EIO;
+    }
+    fclose(f);
+    return 0;
+#else
+    (void)device; (void)vid; (void)pid;
+    return -ENOSYS;
+#endif
+}

--- a/port/platform/win/serial.c
+++ b/port/platform/win/serial.c
@@ -1,0 +1,229 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include "serial.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct serial {
+    HANDLE   handle;
+    unsigned baudrate;
+    char    *device;
+};
+
+int serial_open(struct serial **out, const char *path)
+{
+    struct serial *s = calloc(1, sizeof(*s));
+    if (!s)
+        return -ENOMEM;
+
+    s->device = _strdup(path);
+    if (!s->device) {
+        free(s);
+        return -ENOMEM;
+    }
+
+    /* Ports above COM9 require the \\.\COMn prefix. */
+    char win_path[64];
+    if (strncmp(path, "\\\\.\\", 4) != 0)
+        snprintf(win_path, sizeof(win_path), "\\\\.\\%s", path);
+    else
+        strncpy(win_path, path, sizeof(win_path) - 1);
+
+    s->handle = CreateFileA(win_path,
+                            GENERIC_READ | GENERIC_WRITE,
+                            0, NULL, OPEN_EXISTING,
+                            FILE_ATTRIBUTE_NORMAL, NULL);
+    if (s->handle == INVALID_HANDLE_VALUE) {
+        int err = (GetLastError() == ERROR_FILE_NOT_FOUND) ? -ENOENT : -EIO;
+        free(s->device);
+        free(s);
+        return err;
+    }
+
+    DCB dcb = { .DCBlength = sizeof(DCB) };
+    if (!GetCommState(s->handle, &dcb)) {
+        CloseHandle(s->handle);
+        free(s->device);
+        free(s);
+        return -EIO;
+    }
+
+    dcb.BaudRate        = CBR_115200;
+    dcb.ByteSize        = 8;
+    dcb.Parity          = NOPARITY;
+    dcb.StopBits        = ONESTOPBIT;
+    dcb.fBinary         = TRUE;
+    dcb.fDtrControl     = DTR_CONTROL_DISABLE;
+    dcb.fRtsControl     = RTS_CONTROL_DISABLE;
+    dcb.fOutxCtsFlow    = FALSE;
+    dcb.fOutxDsrFlow    = FALSE;
+    dcb.fDsrSensitivity = FALSE;
+    dcb.fOutX           = FALSE;
+    dcb.fInX            = FALSE;
+    dcb.fNull           = FALSE;
+    dcb.fAbortOnError   = FALSE;
+
+    if (!SetCommState(s->handle, &dcb)) {
+        CloseHandle(s->handle);
+        free(s->device);
+        free(s);
+        return -EIO;
+    }
+
+    SetupComm(s->handle, 4096, 4096);
+    s->baudrate = 115200;
+
+    *out = s;
+    return 0;
+}
+
+void serial_close(struct serial *s)
+{
+    if (!s)
+        return;
+    if (s->handle != INVALID_HANDLE_VALUE)
+        CloseHandle(s->handle);
+    free(s->device);
+    free(s);
+}
+
+int serial_set_baud(struct serial *s, unsigned baud)
+{
+    DCB dcb = { .DCBlength = sizeof(DCB) };
+    if (!GetCommState(s->handle, &dcb))
+        return -EIO;
+    dcb.BaudRate = (DWORD)baud;
+    if (!SetCommState(s->handle, &dcb))
+        return -EIO;
+    s->baudrate = baud;
+    return 0;
+}
+
+ssize_t serial_read(struct serial *s, void *buf, size_t n, unsigned timeout_ms)
+{
+    COMMTIMEOUTS ct = {
+        .ReadIntervalTimeout         = MAXDWORD,
+        .ReadTotalTimeoutMultiplier  = MAXDWORD,
+        .ReadTotalTimeoutConstant    = (DWORD)timeout_ms,
+        .WriteTotalTimeoutMultiplier = 0,
+        .WriteTotalTimeoutConstant   = 0,
+    };
+    SetCommTimeouts(s->handle, &ct);
+
+    DWORD got = 0;
+    if (!ReadFile(s->handle, buf, (DWORD)n, &got, NULL))
+        return -1;
+    return (ssize_t)got;
+}
+
+ssize_t serial_write(struct serial *s, const void *buf, size_t n)
+{
+    const uint8_t *p = (const uint8_t *)buf;
+    size_t written = 0;
+    while (written < n) {
+        DWORD w = 0;
+        if (!WriteFile(s->handle, p + written, (DWORD)(n - written), &w, NULL))
+            return -1;
+        written += w;
+    }
+    return (ssize_t)written;
+}
+
+void serial_set_dtr(struct serial *s, int on)
+{
+    EscapeCommFunction(s->handle, on ? SETDTR : CLRDTR);
+}
+
+void serial_set_rts(struct serial *s, int on)
+{
+    EscapeCommFunction(s->handle, on ? SETRTS : CLRRTS);
+}
+
+void serial_set_dtr_rts(struct serial *s, int dtr, int rts)
+{
+    /* Windows has no atomic "set both" API — EscapeCommFunction only handles
+     * one line at a time.  The USB driver layer batches consecutive control
+     * transfers so the two calls arrive as one USB frame on most bridges,
+     * giving the same glitch-free behaviour as TIOCMSET on POSIX. */
+    EscapeCommFunction(s->handle, dtr ? SETDTR : CLRDTR);
+    EscapeCommFunction(s->handle, rts ? SETRTS : CLRRTS);
+}
+
+void serial_flush_input(struct serial *s)
+{
+    PurgeComm(s->handle, PURGE_RXCLEAR);
+}
+
+int serial_list_ports(char ***ports_out)
+{
+    HKEY hkey;
+    if (RegOpenKeyExA(HKEY_LOCAL_MACHINE,
+                      "HARDWARE\\DEVICEMAP\\SERIALCOMM",
+                      0, KEY_READ, &hkey) != ERROR_SUCCESS)
+        return -ENOENT;
+
+    char **list  = NULL;
+    int    count = 0;
+    DWORD  idx   = 0;
+
+    while (1) {
+        char  name[256], value[256];
+        DWORD name_len  = sizeof(name);
+        DWORD value_len = sizeof(value);
+        DWORD type;
+
+        LONG rc = RegEnumValueA(hkey, idx++, name, &name_len,
+                                NULL, &type, (BYTE *)value, &value_len);
+        if (rc == ERROR_NO_MORE_ITEMS)
+            break;
+        if (rc != ERROR_SUCCESS || type != REG_SZ)
+            continue;
+
+        char **tmp = realloc(list, (size_t)(count + 2) * sizeof(char *));
+        if (!tmp)
+            break;
+        list = tmp;
+        list[count] = _strdup(value);
+        if (!list[count])
+            break;
+        list[++count] = NULL;
+    }
+
+    RegCloseKey(hkey);
+
+    if (!list) {
+        list = calloc(1, sizeof(char *));
+        if (!list)
+            return -ENOMEM;
+        list[0] = NULL;
+    }
+
+    *ports_out = list;
+    return count;
+}
+
+void serial_free_port_list(char **ports)
+{
+    if (!ports)
+        return;
+    for (char **p = ports; *p; p++)
+        free(*p);
+    free(ports);
+}
+
+int serial_get_usb_id(const char *device, unsigned int *vid, unsigned int *pid)
+{
+    /* TODO: implement via SetupDiGetDeviceRegistryProperty + CM_Get_DevNode_Property */
+    (void)device; (void)vid; (void)pid;
+    return -ENOSYS;
+}

--- a/port/serial.h
+++ b/port/serial.h
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file serial.h
+ * @brief Small portable serial-port API for the ESPLoader protocol.
+ *
+ * Supports 8N1 serial without flow control.
+ * Platform code lives in platform/{posix,win}/serial.c.
+ */
+
+#ifndef ESF_SERIAL_H
+#define ESF_SERIAL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef _WIN32
+#  include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#else
+#  include <sys/types.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque handle — definition is platform-specific. */
+struct serial;
+
+/**
+ * Open a serial device in 8N1 raw mode (no echo, no flow control).
+ * @param out  Receives the allocated handle on success.
+ * @param path Device path, e.g. "/dev/ttyUSB0" or "COM3".
+ * @return 0 on success, negative errno on failure.
+ */
+int serial_open(struct serial **out, const char *path);
+
+/**
+ * Close and free a serial handle. Safe to call on NULL.
+ */
+void serial_close(struct serial *s);
+
+/**
+ * Change the baud rate of an open port.
+ * @return 0 on success, negative errno on failure.
+ */
+int serial_set_baud(struct serial *s, unsigned baud);
+
+/**
+ * Read up to @p n bytes with a millisecond timeout.
+ * @return Bytes read (>0), 0 on timeout, -1 on error (errno set).
+ */
+ssize_t serial_read(struct serial *s, void *buf, size_t n, unsigned timeout_ms);
+
+/**
+ * Write @p n bytes, retrying on partial writes and EINTR.
+ * @return Bytes written on success, -1 on error (errno set).
+ */
+ssize_t serial_write(struct serial *s, const void *buf, size_t n);
+
+/**
+ * Set the DTR modem control line.
+ * @param on 1 to assert, 0 to deassert.
+ */
+void serial_set_dtr(struct serial *s, int on);
+
+/**
+ * Set the RTS modem control line.
+ * @param on 1 to assert, 0 to deassert.
+ */
+void serial_set_rts(struct serial *s, int on);
+
+/**
+ * Set both DTR and RTS atomically.
+ *
+ * On POSIX uses a single TIOCMSET ioctl; on Windows relies on the USB
+ * driver batching consecutive EscapeCommFunction calls into one USB frame.
+ * Use this in all reset sequences to avoid glitches on USB-UART bridges.
+ */
+void serial_set_dtr_rts(struct serial *s, int dtr, int rts);
+
+/**
+ * Discard all bytes waiting in the receive buffer.
+ */
+void serial_flush_input(struct serial *s);
+
+/**
+ * Enumerate available serial ports.
+ * @param ports_out Receives a NULL-terminated array of heap-allocated strings.
+ * @return Number of ports found (>=0), or negative errno on failure.
+ */
+int serial_list_ports(char ***ports_out);
+
+/**
+ * Free a port list returned by serial_list_ports().
+ */
+void serial_free_port_list(char **ports);
+
+/**
+ * Read the USB vendor and product IDs for a serial device from the OS.
+ * Currently implemented on Linux only; returns -ENOSYS elsewhere.
+ * @return 0 on success, negative errno on failure.
+ */
+int serial_get_usb_id(const char *device, unsigned int *vid, unsigned int *pid);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESF_SERIAL_H */


### PR DESCRIPTION
Adds a self-contained port/ directory implementing the esp-serial-flasher
port interface (esp_loader_port_ops_t) on top of a thin platform serial
abstraction lifted from esp-ice.

Structure:
  port/serial.h                 portable serial API
  port/esf_port.h/.c            common port: I/O, timer, reset sequences
  port/platform/posix/serial.c  Linux + macOS (termios, TIOCMSET, glob)
  port/platform/win/serial.c    Windows (CreateFile, EscapeCommFunction)
  port/CMakeLists.txt           selects platform at build time

Reset sequences use serial_set_dtr_rts() exclusively throughout, which
is atomic on POSIX (TIOCMSET) and driver-batched on Windows, collapsing
ClassicReset and UnixTightReset into a single path with no platform
branching. USBJTAGSerialReset is handled via VID/PID detection (Linux
sysfs). No pyserial quirks are carried over as they do not apply to
native C serial I/O.

https://claude.ai/code/session_01VL9yD6Bq4CeYiSegLa6FgZ